### PR TITLE
Required changes to CISC191IO Test file  syntax and logic errors

### DIFF
--- a/CISC191IO/src/edu/sdmesa/cisc191/IOTest.java
+++ b/CISC191IO/src/edu/sdmesa/cisc191/IOTest.java
@@ -72,7 +72,7 @@ class IOTest
 //		assertTrue(dateTimeBefore.startsWith("202"));
 //		assertTrue(dateTimeBefore.contains("T"));
 //		assertTrue(dateTimeBefore.endsWith(":00")); // depending on your timezone
-//	    assertTrue(dataTimeBefore.length() == 32);
+//	    assertTrue(dateTimeBefore.length() == 32);
 //		// Wait a sec...
 //		Thread.sleep(1000);
 //		String dateTimeAfter = IO.readDateTime("http://worldtimeapi.org/api/ip");

--- a/CISC191IO/src/edu/sdmesa/cisc191/IOTest.java
+++ b/CISC191IO/src/edu/sdmesa/cisc191/IOTest.java
@@ -60,7 +60,7 @@ class IOTest
 //   }
 
 //	@Test
-//	void testReadDateTime()
+//	void testReadDateTime()  throws InterruptedException
 //	{
 //		// In this test you will "read" the current time from a time server on the internet.
 //		// You can see that the server responds with by entering the URL in a browser
@@ -74,7 +74,7 @@ class IOTest
 //		assertTrue(dateTimeBefore.endsWith(":00")); // depending on your timezone
 //	    assertTrue(dateTimeBefore.length() == 32);
 //		// Wait a sec...
-//		Thread.sleep(1000);
+//		Thread.sleep(1000);  // throws InterruptedException
 //		String dateTimeAfter = IO.readDateTime("http://worldtimeapi.org/api/ip");
 //		long timeBefore = java.sql.Timestamp.valueOf(dateTimeBefore).getTime();
 //		long timeAfter = java.sql.Timestamp.valueOf(dateTimeAfter).getTime();

--- a/CISC191IO/src/edu/sdmesa/cisc191/IOTest.java
+++ b/CISC191IO/src/edu/sdmesa/cisc191/IOTest.java
@@ -59,27 +59,27 @@ class IOTest
 //      assertTrue(results.endsWith("Alice,Westergaard,100,A"));
 //   }
 
-//	@Test
-//	void testReadDateTime()  throws InterruptedException
-//	{
-//		// In this test you will "read" the current time from a time server on the internet.
-//		// You can see that the server responds with by entering the URL in a browser
-//		// and selecting Raw Data. The timestamps always have the same length: 32 characters.
-//		String dateTimeBefore = IO.readDateTime("http://worldtimeapi.org/api/ip");
-//		// Hint: use URL: https://docs.oracle.com/en%2Fjava%2Fjavase%2F21%2Fdocs%2Fapi%2F%2F/java.base/java/net/URL.html
-//		// or URI: https://docs.oracle.com/en%2Fjava%2Fjavase%2F21%2Fdocs%2Fapi%2F%2F/java.base/java/net/URI.html
-//		// Hint: use String's indexOf("\"datetime\":\", 0)
-//		assertTrue(dateTimeBefore.startsWith("202"));
-//		assertTrue(dateTimeBefore.contains("T"));
-//		assertTrue(dateTimeBefore.endsWith(":00")); // depending on your timezone
-//	    assertTrue(dateTimeBefore.length() == 32);
-//		// Wait a sec...
-//		Thread.sleep(1000);  // throws InterruptedException
-//		String dateTimeAfter = IO.readDateTime("http://worldtimeapi.org/api/ip");
-//		long timeBefore = java.sql.Timestamp.valueOf(dateTimeBefore).getTime();
-//		long timeAfter = java.sql.Timestamp.valueOf(dateTimeAfter).getTime();
-//		// Check that time moves forward
-//		assertTrue(timeAfter > timeBefore);
-//	}
+	@Test
+	void testReadDateTime()  throws InterruptedException
+	{
+		// In this test you will "read" the current time from a time server on the internet.
+		// You can see that the server responds with by entering the URL in a browser
+		// and selecting Raw Data. The timestamps always have the same length: 32 characters.
+		String dateTimeBefore = IO.readDateTime("http://worldtimeapi.org/api/ip");
+		// Hint: use URL: https://docs.oracle.com/en%2Fjava%2Fjavase%2F21%2Fdocs%2Fapi%2F%2F/java.base/java/net/URL.html
+		// or URI: https://docs.oracle.com/en%2Fjava%2Fjavase%2F21%2Fdocs%2Fapi%2F%2F/java.base/java/net/URI.html
+		// Hint: use String's indexOf("\"datetime\":\", 0)
+		assertTrue(dateTimeBefore.startsWith("202"));
+		assertTrue(dateTimeBefore.contains("T"));
+		assertTrue(dateTimeBefore.endsWith(":00")); // depending on your timezone
+	    assertTrue(dateTimeBefore.length() == 32);
+		// Wait a sec...
+		Thread.sleep(1000);  // throws InterruptedException
+		String dateTimeAfter = IO.readDateTime("http://worldtimeapi.org/api/ip");
+		long timeBefore = java.sql.Timestamp.valueOf(dateTimeBefore).getTime();
+		long timeAfter = java.sql.Timestamp.valueOf(dateTimeAfter).getTime();
+		// Check that time moves forward
+		assertTrue(timeAfter > timeBefore);
+	}
 
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CISC191ProgrammingChallenges
-Programming challenges for San Diego Community College CISC-191 Intermediate Java classes.
+Programming challenges for San Diego Community College CISC 191 Intermediate Java classes.
 
 Created by Professor Dr. Tasha Frankie and Professor Allan Schougaard, San Diego Mesa College.
 With contributions from: Dom David

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CISC191ProgrammingChallenges
-Programming challenges for San Diego Community College CISC 191 Intermediate Java classes.
+Programming challenges for San Diego Community College CISC-191 Intermediate Java classes.
 
 Created by Professor Dr. Tasha Frankie and Professor Allan Schougaard, San Diego Mesa College.
 With contributions from: Dom David


### PR DESCRIPTION
5 commits:

1.   in-class demo. 1 character added to README.
2.   reverted 1 character change in repository.
3.   typo in IOTest  "dataTimeBefore" change to "dateTimeBefore"
4.   add "throws InterruptedException" for thread.sleep()
5.   timestamp is returned with timezone, must be reformatted first.