### PR TITLE
Fix Animated Clock test.

### DIFF
--- a/CISC191AnimatedClock/src/edu/sdmesa/cisc191/TestClock.java
+++ b/CISC191AnimatedClock/src/edu/sdmesa/cisc191/TestClock.java
@@ -29,9 +29,9 @@ class TestClock
 	{
 		Clock clock = new Clock();
 		assertEquals("00:00", clock.getTime());
-		Thread.sleep(1050);
+		Thread.sleep(1500);
 		assertEquals("00:01", clock.getTime());
-		Thread.sleep(1050);
+		Thread.sleep(1100);
 		assertEquals("00:02", clock.getTime());
 	}
 

--- a/CISC191AnimatedClock/src/edu/sdmesa/cisc191/TestClock.java
+++ b/CISC191AnimatedClock/src/edu/sdmesa/cisc191/TestClock.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
+import java.awt.Dimension;
+
+import javax.swing.JFrame;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +41,11 @@ class TestClock
 	@Test
 	void testClockPanel() throws InterruptedException
 	{
+		JFrame window = new JFrame();
+		window.setSize(new Dimension(400,400));
+		window.setVisible(true);
 		ClockPanel panel = new ClockPanel(Color.BLACK, Color.GREEN);
+		window.add(panel);
 		panel.repaint();
 
 		// Testing that the panel animates the clock


### PR DESCRIPTION
1. minor changes (extend) timeout to wait for different machines to render resources.  tested across platforms (including classroom machines)
2. testClockPanel():  as written, the panel default size is too small to allow movement... changed dimensions in test panel to allow movement.