### PR TITLE
fixed M4 Test 3 vars not declared

### DIFF
--- a/CISC191M4AdvancedClasses/src/cisc191/sdmesa/edu/TestAdvancedClasses.java
+++ b/CISC191M4AdvancedClasses/src/cisc191/sdmesa/edu/TestAdvancedClasses.java
@@ -107,11 +107,12 @@ class TestAdvancedClasses
 //	{
 //		Cycle cycle1 = new Unicycle("Uni");
 //		cycle1.setColor(Color.RED);
-//		cycle1FrameNumber = cycle1.getFrameNumber();
+//		int cycle1FrameNumber = cycle1.getFrameNumber();
 //		assertEquals("Uni (" + cycle1FrameNumber +")", cycle1.toString());
 //		
 //		Cycle cycle2 = new Unicycle("Uni"); 
 //		cycle2.setColor(Color.BLUE);
+//		int cycle2FrameNumber = cycle2.getFrameNumber();
 //		assertEquals("Uni (" + cycle2FrameNumber +")", cycle2.toString());
 //
 //		assertNotEquals(cycle1.toString(), cycle2.toString());
@@ -239,3 +240,4 @@ class TestAdvancedClasses
 //	}
 
 }
+


### PR DESCRIPTION
In M4 TestAdvancedClasses.java, Test Order(3)'s cycle1FrameNumber and cycle2FrameNumber variables were not properly declared. Found by a student!